### PR TITLE
Tradução de rodapé de email Fix #26

### DIFF
--- a/src/pt_BR.json
+++ b/src/pt_BR.json
@@ -19,6 +19,7 @@
     "Verify Email Address": "Verificar E-mail",
     "If you did not create an account, no further action is required." : "Se você não criou a conta, favor desconsiderar este e-mail",
     "If you’re having trouble clicking the \":actionText\" button, copy and paste the URL below\ninto your web browser:": "Se você estiver com problemas para clicar no botão \":actionText\", copie e cole o URL abaixo\nem seu navegador da web:",
+    "If you’re having trouble clicking the \":actionText\" button, copy and paste the URL below\ninto your web browser: [:displayableActionUrl](:actionURL)":  "Se você estiver com problemas para clicar no botão \":actionText\", copie e cole o URL abaixo\nem seu navegador da web: [:displayableActionUrl](:actionURL)",
     "Send Password Reset Link": "Enviar link para redifinir senha",
     "Reset Password": "Modificar Senha",
     "You are receiving this email because we received a password reset request for your account.": "Você está recebendo este e-mail porque recebemos uma solicitação de redefinição de senha para sua conta.",


### PR DESCRIPTION
Fix #26 

Não testei em versões mais recentes ou anteriores, portanto apenas adicionei uma nova linha, presumindo que a linha existente é funcional em algum caso.