### PR TITLE
Colocando o pacote nas dependências de desenvolvimento.

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 1. Instale o pacote
   ```shell
-  $ composer require lucascudo/laravel-pt-br-localization
+  $ composer require lucascudo/laravel-pt-br-localization --dev
   ```
 2. Publique as traduções
   ```shell


### PR DESCRIPTION
Penso que o pacote deveria ser instalado somente no ambiente de desenvolvimento.
Não precisa ser instalado em produção já que não vão ser republicadas as traduções em produção.