### PR TITLE
Tradução para novas regras de validação adicionada

### DIFF
--- a/src/pt_BR/validation.php
+++ b/src/pt_BR/validation.php
@@ -104,6 +104,7 @@ return [
     'required_with_all'    => 'O campo :attribute é obrigatório quando :values está presente.',
     'required_without'     => 'O campo :attribute é obrigatório quando :values não está presente.',
     'required_without_all' => 'O campo :attribute é obrigatório quando nenhum dos :values estão presentes.',
+    'prohibited'           => 'O campo :attribute é proibido.',
     'prohibited_if'        => 'O campo :attribute é proibido quando :other for :value.',
     'prohibited_unless'    => 'O campo :attribute é proibido exceto quando :other for :values.',
     'same'                 => 'Os campos :attribute e :other devem corresponder.',

--- a/src/pt_BR/validation.php
+++ b/src/pt_BR/validation.php
@@ -91,6 +91,7 @@ return [
         'array'   => 'O campo :attribute deve ter pelo menos :min itens.',
     ],
     'not_in'               => 'O campo :attribute selecionado é inválido.',
+    'multiple_of'          => 'O campo :attribute deve ser um múltiplo de :value.',
     'not_regex'            => 'O campo :attribute possui um formato inválido.',
     'numeric'              => 'O campo :attribute deve ser um número.',
     'password'             => 'A senha está incorreta.',

--- a/src/pt_BR/validation.php
+++ b/src/pt_BR/validation.php
@@ -104,6 +104,8 @@ return [
     'required_with_all'    => 'O campo :attribute é obrigatório quando :values está presente.',
     'required_without'     => 'O campo :attribute é obrigatório quando :values não está presente.',
     'required_without_all' => 'O campo :attribute é obrigatório quando nenhum dos :values estão presentes.',
+    'prohibited_if'        => 'O campo :attribute é proibido quando :other for :value.',
+    'prohibited_unless'    => 'O campo :attribute é proibido exceto quando :other for :values.',
     'same'                 => 'Os campos :attribute e :other devem corresponder.',
     'size'                 => [
         'numeric' => 'O campo :attribute deve ser :size.',


### PR DESCRIPTION
Esse PR adiciona tradução para as novas regras de validação `multiple_of`, `prohibited` (lançada no Laravel 8.34), `prohibited_if` e `prohibited_unless` (lançadas no Laravel 8.32).