### PR TITLE
docs: :memo: add a reference to timezone usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,11 @@
   // Altere Linha 83 do arquivo config/app.php para:
   'locale' => 'pt_BR',
   ```
+4. Configure o Framework para utilizar 'America/Sao_Paulo' como data hora padrão
+  ```
+  // Altere Linha 70 do arquivo config/app.php para:
+  'timezone' => 'America/Sao_Paulo',
+  ```
 ## Versões do Laravel suportadas
 
 * 8.x


### PR DESCRIPTION
add a timezone referente to America/Sao_Paulo

adicionado uma referência ao **README.md**, orientando uma forma de se utilizar o fuso horário brasileiro na aplicação em conjunto com as configurações do idioma brasileiro.