### PR TITLE
fix: readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,32 +4,38 @@
 
 ## Instalação
 
-1. Instale o pacote
-  ```shell
-  $ composer require lucascudo/laravel-pt-br-localization --dev
-  ```
-2. Publique as traduções
-  ```shell
-  $ php artisan vendor:publish --tag=laravel-pt-br-localization
-  ```
-3. Configure o Framework para utilizar 'pt_BR' como linguagem padrão
-  ```
-  // Altere Linha 83 do arquivo config/app.php para:
-  'locale' => 'pt_BR',
-  ```
+1.  Instale o pacote
+
+```shell
+composer require lucascudo/laravel-pt-br-localization --dev
+```
+
+2.  Publique as traduções
+
+```shell
+php artisan vendor:publish --tag=laravel-pt-br-localization
+```
+
+3.  Configure o Framework para utilizar 'pt_BR' como linguagem padrão
+
+```
+// Altere Linha 83 do arquivo config/app.php para:
+'locale' => 'pt_BR',
+```
+
 ## Versões do Laravel suportadas
 
-* 8.x
-* 7.x
-* 6.x
-* 5.8
-* 5.7
-* 5.6
+-   8.x
+-   7.x
+-   6.x
+-   5.8
+-   5.7
+-   5.6
 
 ## Suporte a versões anteriores do Laravel
 
-* [Laravel 5.5](https://github.com/enniosousa/laravel-5.5-pt-BR-localization)
-* [Laravel 5.4](https://github.com/Leomhl/laravel-5.4-pt-br-localization)
-* [Laravel 5.3](https://github.com/leandroluk/laravel-5.3-pt-br-localization)
-* [Laravel 5.2](https://github.com/felipeporto/laravel-5.2-pt-br-localization)
-* [Laravel 5.1](https://github.com/bmonteirog/laravel-5.1-pt-br-localization)
+-   [Laravel 5.5](https://github.com/enniosousa/laravel-5.5-pt-BR-localization)
+-   [Laravel 5.4](https://github.com/Leomhl/laravel-5.4-pt-br-localization)
+-   [Laravel 5.3](https://github.com/leandroluk/laravel-5.3-pt-br-localization)
+-   [Laravel 5.2](https://github.com/felipeporto/laravel-5.2-pt-br-localization)
+-   [Laravel 5.1](https://github.com/bmonteirog/laravel-5.1-pt-br-localization)


### PR DESCRIPTION
Agora que temos [copy-paste de código no GitHub](https://twitter.com/natfriedman/status/1391862005095485440) os prefixos `$` do Readme se tornaram um problema. Se você simplesmente clicar no atalho de cópia e tentar colar, não vai funcionar. 

Como não são relevantes estou apenas removendo eles. Aproveitei para corrigir a formatação do arquivo.