### PR TITLE
Correção de compatibilidade do diretório lang

### DIFF
--- a/src/LaravelPtBRLocalizationServiceProvider.php
+++ b/src/LaravelPtBRLocalizationServiceProvider.php
@@ -1,6 +1,9 @@
 <?php
+
 namespace Lucascudo\LaravelPtBRLocalization;
+
 use Illuminate\Support\ServiceProvider;
+
 class LaravelPtBRLocalizationServiceProvider extends ServiceProvider
 {
     /**
@@ -10,10 +13,9 @@ class LaravelPtBRLocalizationServiceProvider extends ServiceProvider
     */
     public function register()
     {
-        $path_command = 'resource_path';//(substr(app()->version(), 0, 1) > 8 && method_exists(app(), 'langPath')) ? app()['langPath'] : resource_path;
         $this->publishes([
-            __DIR__ . '/pt-BR.json' => $path_command('lang/pt-BR.json'),
-            __DIR__ . '/pt-BR' => $path_command('lang/pt-BR'),
+            __DIR__ . '/pt-BR.json' => $this->app->langPath() . '/pt-BR.json',
+            __DIR__ . '/pt-BR' => $this->app->langPath() . '/pt-BR',
         ], 'laravel-pt-br-localization');
     }
 }


### PR DESCRIPTION
Conforme visto nas issues recentes (https://github.com/lucascudo/laravel-pt-BR-localization/issues/50, https://github.com/lucascudo/laravel-pt-BR-localization/issues/53 e https://github.com/lucascudo/laravel-pt-BR-localization/issues/55), existe um problema de compatibilidade com as diferentes versões do Laravel suportadas pelo pacote: `v5.6.x ~ v9.x.x`.

Isso faz com que os arquivos de tradução não sejam publicados no diretório correto em alguns casos, pois houve uma mudança recente na localização do diretório `lang` do framework.

### Solução

Utilização do método `langPath()` que está disponível na classe `Illuminate/Foundation/Application` em todas as versões do Laravel que o pacote suporta, como pode ser visto na documentação:
- `v5.5.x`: https://laravel.com/api/5.5/Illuminate/Foundation/Application.html#method_langPath
- `v9.x.x`: https://laravel.com/api/9.x/Illuminate/Foundation/Application.html#method_langPath

Dessa forma, não é preciso efetuar a verificação de qual versão o framework está para então publicar os arquivos no diretório correto. Esse controle fica sob responsabilidade do próprio Laravel.

A solução implementada foi testada nas versões `5.6.33` e `9.14.0` do Laravel.