### PR TITLE
Add Email Address

### DIFF
--- a/src/pt-BR.json
+++ b/src/pt-BR.json
@@ -13,6 +13,7 @@
     "Register": "Registre-se",
     "Home": "Principal",
     "Logout": "Sair",
+	"Email Address": "Endereço de e-mail",
     "Toggle navigation": "Alternar navegação",
     "Nevermind": "Deixa pra lá",
     "Verify Your Email Address": "Verifique seu endereço de e-mail",


### PR DESCRIPTION
Bom dia,

No laravel 9 utilizando o boodstrap auth ele não traduzia o campo Endereço de e-mail para português.

O que fiz foi só adicionar essa nova constante no arquivo json e o problema foi resolvido.

Para simular o problema Execute os seguintes passos:
```
composer create-project laravel/laravel teste
composer require laravel/ui
php artisan ui bootstrap –auth
npm install bootstrap@latest bootstrap-icons @popperjs/core –save-dev
No arquivo app.scss adicione a seguinte linha
@import '~bootstrap-icons/font/bootstrap-icons';
```

Por Fim
```
npm install
npm run dev
```
Depois instale o pacote 
Verá que no /login ele não ira traduzir o campo











