### PR TITLE
added validation summary translations

### DIFF
--- a/src/pt-BR.json
+++ b/src/pt-BR.json
@@ -118,5 +118,8 @@
     "Enable": "Habilitar",
     "Regenerate Recovery Codes": "Gerar novamente os códigos de recuperação",
     "Show Recovery Codes": "Mostrar os códigos de recuperação",
-    "Disable": "Desabilitar"
+    "Disable": "Desabilitar",
+    "The given data was invalid." : "Os dados fornecidos são inválidos.",
+    "(and :count more error)": "(e mais :count erro)",
+    "(and :count more errors)": "(e mais :count erros)"
 }


### PR DESCRIPTION
Added translations used in the `summarize` method of `ValidationException` (`\Illuminate\Validation\ValidationException::summarize`)

Full method definition:
```php
/**
 * Create an error message summary from the validation errors.
 *
 * @param  \Illuminate\Contracts\Validation\Validator  $validator
 * @return string
 */
protected static function summarize($validator)
{
    $messages = $validator->errors()->all();

    if (! count($messages) || ! is_string($messages[0])) {
        return $validator->getTranslator()->get('The given data was invalid.');
    }

    $message = array_shift($messages);

    if ($count = count($messages)) {
        $pluralized = $count === 1 ? 'error' : 'errors';

        $message .= ' '.$validator->getTranslator()->get("(and :count more $pluralized)", compact('count'));
    }

    return $message;
}
```