### PR TITLE
Translated messages for 'max_digits' and 'min_digits' validation rules

### DIFF
--- a/src/pt-BR/validation.php
+++ b/src/pt-BR/validation.php
@@ -88,6 +88,7 @@ return [
         'string'  => 'O campo :attribute não pode ser superior a :max caracteres.',
         'array'   => 'O campo :attribute não pode ter mais do que :max itens.',
     ],
+    'max_digits'           => 'O campo :attribute não pode ser superior a :max dígitos',
     'mimes'                => 'O campo :attribute deve ser um arquivo do tipo: :values.',
     'mimetypes'            => 'O campo :attribute deve ser um arquivo do tipo: :values.',
     'min' => [
@@ -96,6 +97,7 @@ return [
         'string'  => 'O campo :attribute deve ter pelo menos :min caracteres.',
         'array'   => 'O campo :attribute deve ter pelo menos :min itens.',
     ],
+    'min_digits'           => 'O campo :attribute deve ter pelo menos :min dígitos',
     'not_in'               => 'O campo :attribute selecionado é inválido.',
     'multiple_of'          => 'O campo :attribute deve ser um múltiplo de :value.',
     'not_regex'            => 'O campo :attribute possui um formato inválido.',


### PR DESCRIPTION
Adding the pt-BR messages for the 'max_digits' and 'min_digits' validation rules, as mentioned in the [issue#63](https://github.com/lucascudo/laravel-pt-BR-localization/issues/63)