### PR TITLE
Inclusion of password outside the records

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -1,0 +1,18 @@
+{
+    "_readme": [
+        "This file locks the dependencies of your project to a known state",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
+        "This file is @generated automatically"
+    ],
+    "content-hash": "b111209bf2f89163dc336aa7b35f5ffb",
+    "packages": [],
+    "packages-dev": [],
+    "aliases": [],
+    "minimum-stability": "stable",
+    "stability-flags": [],
+    "prefer-stable": false,
+    "prefer-lowest": false,
+    "platform": [],
+    "platform-dev": [],
+    "plugin-api-version": "2.0.0"
+}

--- a/src/pt_BR.json
+++ b/src/pt_BR.json
@@ -104,6 +104,7 @@
   "The :attribute must be at least :length characters.": "O campo :attribute deve ter pelo menos :length caracteres.",
   "The given data was invalid.": "Os dados fornecidos são inválidos.",
   "This is a secure area of the application. Please confirm your password before continuing.": "Essa é uma área segura da aplicação. Por favor confirme sua senha antes de continuar.",
+  "This password does not match our records.":"Esta Senha não bate com nossos registros",
   "This password reset link will expire in :count minutes.": "Este link de redefinição de senha expirará em :count minutos.",
   "Toggle navigation": "Alternar navegação",
   "Token Name": "Nome do Token",

--- a/src/pt_BR.json
+++ b/src/pt_BR.json
@@ -104,7 +104,7 @@
   "The :attribute must be at least :length characters.": "O campo :attribute deve ter pelo menos :length caracteres.",
   "The given data was invalid.": "Os dados fornecidos são inválidos.",
   "This is a secure area of the application. Please confirm your password before continuing.": "Essa é uma área segura da aplicação. Por favor confirme sua senha antes de continuar.",
-  "This password does not match our records.":"Esta Senha não bate com nossos registros",
+  "This password does not match our records.": "Esta Senha não bate com nossos registros.",
   "This password reset link will expire in :count minutes.": "Este link de redefinição de senha expirará em :count minutos.",
   "Toggle navigation": "Alternar navegação",
   "Token Name": "Nome do Token",


### PR DESCRIPTION
Inclusão de retorno de senha fora dos registros na captação do JETSTREAM no Modal de Autenticação em 2 fatores. Com esta inclusão o Jeststream faz a perfeita captação da mensagem em portugues quando se está utilizando o ADMINLTE junto. Com esta inclusão no arquivo pr_BR.json o retorno é perfeito.