### PR TITLE
Adding laravel 11 tag.

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ php artisan vendor:publish --tag=laravel-pt-br-localization
 
 ## Versões do Laravel suportadas
 
+-   11.x
 -   10.x
 -   9.x
 -   8.x


### PR DESCRIPTION
I performed tests on laravel 11 and confirmed the library's compatibility with the new version of laravel.