### PR TITLE
feat: Adicionar mensagem do modal de confirmar senha

### DIFF
--- a/src/pt_BR.json
+++ b/src/pt_BR.json
@@ -158,5 +158,6 @@
   "You have not enabled two factor authentication.": "Você ainda não habilitou a autenticação de dois fatores.",
   "You may delete any of your existing tokens if they are no longer needed.": "Você deve deletar os tokens sem utilização.",
   "Your email address is unverified.": "Seu endereço de e-mail não foi verificado.",
-  "Photo": "Foto"
+  "Photo": "Foto",
+  "For your security, please confirm your password to continue.": "Por segurança, por favor confirme sua senha para continuar."
 }


### PR DESCRIPTION
Essa mensagem aparece no modal de confirmar senha do jetstream, que é utilizado nas ações de habilitar/desabilitar autenticação MFA

![image](https://github.com/user-attachments/assets/6069123b-4cc5-4254-83ac-d33c6c3a1707)

[Link do arquivo](https://github.com/laravel/jetstream/blob/5.x/stubs/livewire/resources/views/components/confirms-password.blade.php#L1)